### PR TITLE
Add nodejs version of zip password calculator

### DIFF
--- a/zip_password_calculator/README.md
+++ b/zip_password_calculator/README.md
@@ -18,8 +18,13 @@ ro.product.locale.region=GB
 Most of these values should be either static or guessable with a bit of detective work.
 
 Example:
-```
+```sh
 $ ./zip_password_calculator.sh build.prop.TEST
+15DAA85C8D44B3979CD152A387F6
+```
+
+```sh
+$ node ./zip_password_calculator.mjs build.prop.TEST
 15DAA85C8D44B3979CD152A387F6
 ```
 

--- a/zip_password_calculator/zip_password_calculator.mjs
+++ b/zip_password_calculator/zip_password_calculator.mjs
@@ -1,0 +1,44 @@
+#!/bin/env node
+
+import { readFile } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
+
+const elements = [
+  'ro.product.model',
+  'ro.product.brand',
+  'ro.product.name',
+  'ro.product.device',
+  'ro.product.board',
+  'ro.product.cpu.abi',
+  'ro.product.cpu.abi2',
+  'ro.product.manufacturer',
+  'ro.product.locale.language',
+  'ro.product.locale.region',
+]
+
+const infile = process.argv[2]
+
+if (!infile) {
+  help()
+  process.exit(1)
+}
+
+const contents = await readFile(infile, 'utf8')
+
+const props = elements.reduce((acc, element) => {
+  const match = contents.match(`${element}=.*`)
+  return match ? [...acc, match[0]] : acc
+}, []).join('')
+
+const hash1 = createHash('sha512').update(props).digest('hex').toUpperCase()
+const hash2 = createHash('sha512').update(hash1).digest('hex').toUpperCase()
+
+console.log(hash2.substring(10, 38))
+
+
+function help() {
+  console.info(`Usage: node zip_password_calculator.mjs FILENAME
+FILENAME should be a 'build.prop' file containing the following elements:
+${elements.join('\n')}`
+  )
+}


### PR DESCRIPTION
This is a rewrite of [`./zip_password_calculator/zip_password_calculator.sh`](https://github.com/rgerganov/gen5fw/blob/master/zip_password_calculator/zip_password_calculator.sh) to NodeJS for those of us who prefer JS over shell scripts